### PR TITLE
added wrapper for jack_midi_get_event_count function

### DIFF
--- a/global.h
+++ b/global.h
@@ -26,6 +26,7 @@
 // JACK includes
 #include <jack/types.h>
 #include <jack/transport.h>
+#include <jack/midiport.h>
 
 namespace QtJack {
 typedef jack_default_audio_sample_t AudioSample;

--- a/global.h
+++ b/global.h
@@ -30,7 +30,7 @@
 
 namespace QtJack {
 typedef jack_default_audio_sample_t AudioSample;
-typedef char MidiSample;
+typedef jack_midi_event_t MidiEvent;
 
 enum TransportState {
     TransportStateStopped,

--- a/midibuffer.cpp
+++ b/midibuffer.cpp
@@ -104,4 +104,8 @@ bool MidiBuffer::pop(MidiRingBuffer &ringBuffer) {
     return false;
 }
 
+unsigned int MidiBuffer::getEventCount() {
+    return (int)jack_midi_get_event_count(_jackBuffer);
+}
+
 } // namespace QtJack

--- a/midibuffer.cpp
+++ b/midibuffer.cpp
@@ -105,7 +105,7 @@ bool MidiBuffer::pop(MidiRingBuffer &ringBuffer) {
 }
 
 unsigned int MidiBuffer::getEventCount() {
-    return (int)jack_midi_get_event_count(_jackBuffer);
+    return (unsigned int)jack_midi_get_event_count(_jackBuffer);
 }
 
 } // namespace QtJack

--- a/midibuffer.cpp
+++ b/midibuffer.cpp
@@ -41,6 +41,7 @@ MidiBuffer::MidiBuffer(int size, void *buffer)
 MidiBuffer::~MidiBuffer() {
 }
 
+#if 0
 bool MidiBuffer::clear() {
     if(!isValid()) {
         return false;
@@ -50,20 +51,30 @@ bool MidiBuffer::clear() {
     }
     return true;
 }
+#endif
 
-MidiSample MidiBuffer::read(int i, bool *ok) const {
+bool MidiBuffer::read(MidiEvent *ms, int i, bool *ok) const {
     if(!isValid()) {
         if(ok) {
             (*ok) = false;
         }
-        return 0.0;
+        return false;
     }
 
     if(ok) {
         (*ok) = true;
     }
-    return (double)((i >= 0 && i < _size) ? ((MidiSample*)(_jackBuffer))[i] : 0.0);
+
+#if 0
+    if(i < 0 || i >= this->getEventCount()) {
+        return false;
+    }
+#endif
+
+    return (jack_midi_event_get(ms, _jackBuffer, i) ? false : true);
 }
+
+#if 0
 
 bool MidiBuffer::write(int i, MidiSample value) {
     if(!isValid()) {
@@ -103,6 +114,8 @@ bool MidiBuffer::pop(MidiRingBuffer &ringBuffer) {
     }
     return false;
 }
+
+#endif
 
 unsigned int MidiBuffer::getEventCount() {
     return (unsigned int)jack_midi_get_event_count(_jackBuffer);

--- a/midibuffer.h
+++ b/midibuffer.h
@@ -36,12 +36,15 @@ public:
     MidiBuffer(const MidiBuffer& other);
     virtual ~MidiBuffer();
 
+#if 0
     /** Sets all samples to zero. */
     bool clear() REALTIME_SAFE;
+#endif
 
     /** @returns sample at position i in the midi buffer. */
-    MidiSample read(int i, bool *ok = 0) const REALTIME_SAFE;
+    bool read(MidiEvent *ms, int i, bool *ok = 0) const REALTIME_SAFE;
 
+#if 0
     /** Writes sample at position i in the midi buffer. */
     bool write(int i, MidiSample value) REALTIME_SAFE;
 
@@ -67,6 +70,7 @@ public:
      * @returns true on succes, false otherwise.
      */
     bool pop(MidiRingBuffer& ringBuffer) REALTIME_SAFE;
+#endif
 
     /**
      * @returns the number of midi events in the buffer.

--- a/midibuffer.h
+++ b/midibuffer.h
@@ -68,6 +68,11 @@ public:
      */
     bool pop(MidiRingBuffer& ringBuffer) REALTIME_SAFE;
 
+    /**
+     * @returns the number of midi events in the buffer.
+     */
+    unsigned int getEventCount();
+
 protected:
     MidiBuffer(int size, void *buffer);
 };

--- a/ringbuffer.h
+++ b/ringbuffer.h
@@ -117,6 +117,6 @@ private:
 };
 
 typedef RingBuffer<AudioSample> AudioRingBuffer;
-typedef RingBuffer<MidiSample> MidiRingBuffer;
+typedef RingBuffer<MidiEvent> MidiRingBuffer;
 
 } // namespace QtJack


### PR DESCRIPTION
I think a wrapper for this function was missing. With this it is possible to know which buffer actually contains jack midi events.
